### PR TITLE
Typo

### DIFF
--- a/blog/best-programming-language-for-beginner.essay.html
+++ b/blog/best-programming-language-for-beginner.essay.html
@@ -531,7 +531,7 @@ Further, Racket emphasizes &ldquo;language oriented programming&rdquo;. It means
 </p>
 
 <p>
-The most recommended book on (functional) programming is the classic &ldquo;Structure and Interpretation of Programming Languages&rdquo;, abbreviatet &ldquo;SICP&rdquo;. It was written as an introduction for computer science students at MIT, using Scheme. But for me it was a bit too much as a very first book. But check it out anyway, it&rsquo;s really philosophical.<br>
+The most recommended book on (functional) programming is the classic &ldquo;Structure and Interpretation of Computer Programs&rdquo;, abbreviatet &ldquo;SICP&rdquo;. It was written as an introduction for computer science students at MIT, using Scheme. But for me it was a bit too much as a very first book. But check it out anyway, it&rsquo;s really philosophical.<br>
 </p>
 
 <p>
@@ -558,7 +558,7 @@ You can get started very easily with Scheme and Racket &#x2013; one single insta
 </ul></li>
 <li>Introduction into computer science:<br>
 <ul class="org-ul">
-<li><a href="https://mitpress.mit.edu/sites/default/files/sicp/index.html">&ldquo;Structure and Interpretation of Programming Languages&rdquo; (free online)</a> | <a href="https://amzn.to/2ZZBS7f">Paper book</a><br></li>
+<li><a href="https://mitpress.mit.edu/sites/default/files/sicp/index.html">&ldquo;Structure and Interpretation of Computer Programs&rdquo; (free online)</a> | <a href="https://amzn.to/2ZZBS7f">Paper book</a><br></li>
 </ul></li>
 </ul>
 


### PR DESCRIPTION
SICP stands for "Structure and Interpretation of Computer Programs", not "Structure and Interpretation of Programming Languages"